### PR TITLE
Feature/be 50 오늘의 집중

### DIFF
--- a/prisma/migrations/20241126022843_update_study_focus_relation_to_one_to_one/migration.sql
+++ b/prisma/migrations/20241126022843_update_study_focus_relation_to_one_to_one/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `endTime` on the `Focus` table. All the data in the column will be lost.
+  - You are about to drop the column `startTime` on the `Focus` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[studyId]` on the table `Focus` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Focus" DROP COLUMN "endTime",
+DROP COLUMN "startTime";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Focus_studyId_key" ON "Focus"("studyId");

--- a/prisma/schema/focus.prisma
+++ b/prisma/schema/focus.prisma
@@ -2,13 +2,11 @@
 /// - 사용자의 학습 집중 시간을 기록하고 포인트를 관리
 /// - startTime과 endTime으로 집중 시간을 측정
 /// - points 필드로 집중도에 따른 보상 포인트를 누적
-/// - Study 모델과 1:N 관계로 연결되어 특정 학습에 대한 집중 기록을 저장
+/// - Study 모델과 1:1 관계로 연결되어 특정 학습에 대한 집중 기록을 저장
 model Focus {
   id        String    @id @default(uuid())
-  studyId   String
+  studyId   String    @unique
   points    Int       @default(0)
-  startTime DateTime?
-  endTime   DateTime?
   study     Study     @relation(fields: [studyId], references: [id], onDelete: Cascade)
 
   @@index([studyId])

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -14,7 +14,7 @@ model Study {
   createdAt       DateTime         @default(now()) @db.Timestamptz(6)
   updatedAt       DateTime         @updatedAt @db.Timestamptz(6)
   completedHabits CompletedHabit[]
-  focuses         Focus[]
+  focus           Focus?
   habits          Habit[]
   reactions       Reaction[]
 }

--- a/src/points/dto/create-point.dto.ts
+++ b/src/points/dto/create-point.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
 
 export class CreatePointDto {
   @ApiProperty({
@@ -7,6 +8,7 @@ export class CreatePointDto {
     example: 5,
     type: Number,
   })
+  @IsNumber()
   points: number = 0;
 
   @ApiProperty({

--- a/src/points/dto/create-point.dto.ts
+++ b/src/points/dto/create-point.dto.ts
@@ -1,1 +1,19 @@
-export class CreatePointDto {}
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreatePointDto {
+  @ApiProperty({
+    nullable: false,
+    description: '포인트 점수',
+    example: 5,
+    type: Number,
+  })
+  points: number = 0;
+
+  @ApiProperty({
+    nullable: false,
+    description: '스터디 아이디',
+    example: '56afe5db-7938-4e93-8198-26c9f84e1335',
+    type: String,
+  })
+  studyId: string;
+}

--- a/src/points/points.controller.ts
+++ b/src/points/points.controller.ts
@@ -1,34 +1,29 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Body, Param, Patch } from '@nestjs/common';
 import { PointsService } from './points.service';
 import { CreatePointDto } from './dto/create-point.dto';
-import { UpdatePointDto } from './dto/update-point.dto';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiCustomDocs } from 'src/shared/swagger/ApiCustomDocs';
 
+@ApiTags('points')
 @Controller('points')
 export class PointsController {
   constructor(private readonly pointsService: PointsService) {}
 
-  @Post()
-  create(@Body() createPointDto: CreatePointDto) {
-    return this.pointsService.create(createPointDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.pointsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.pointsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePointDto: UpdatePointDto) {
-    return this.pointsService.update(+id, updatePointDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.pointsService.remove(+id);
+  @ApiCustomDocs({
+    summary: '포인트 업데이트',
+    description: {
+      title: '포인트를 업데이트를 합니다.',
+      contents: ['포인트 점수를 입력받아 포인트를 추가해서 업데이트를 합니다.'],
+    },
+    requestType: CreatePointDto,
+    responseType: CreatePointDto,
+  })
+  @Patch(':studyId')
+  async updatePoint(
+    @Param('studyId') studyId: string,
+    @Body() createPointDto: CreatePointDto,
+  ) {
+    const data = { ...createPointDto, studyId };
+    return await this.pointsService.updatePoint(data);
   }
 }

--- a/src/points/points.controller.ts
+++ b/src/points/points.controller.ts
@@ -12,7 +12,7 @@ export class PointsController {
   @ApiCustomDocs({
     summary: '포인트 업데이트',
     description: {
-      title: '포인트를 업데이트를 합니다.',
+      title: '포인트를 업데이트합니다.',
       contents: ['포인트 점수를 입력받아 포인트를 추가해서 업데이트를 합니다.'],
     },
     requestType: CreatePointDto,

--- a/src/points/points.module.ts
+++ b/src/points/points.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PointsService } from './points.service';
 import { PointsController } from './points.controller';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 @Module({
   controllers: [PointsController],
-  providers: [PointsService],
+  providers: [PointsService, PrismaService],
 })
 export class PointsModule {}

--- a/src/points/points.service.ts
+++ b/src/points/points.service.ts
@@ -1,26 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { CreatePointDto } from './dto/create-point.dto';
-import { UpdatePointDto } from './dto/update-point.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
 export class PointsService {
-  create(createPointDto: CreatePointDto) {
-    return 'This action adds a new point';
-  }
+  // PrismaService를 주입
+  constructor(private readonly prisma: PrismaService) {}
 
-  findAll() {
-    return `This action returns all points`;
-  }
+  async updatePoint(createPointDto: CreatePointDto) {
+    const { studyId, points } = createPointDto;
 
-  findOne(id: number) {
-    return `This action returns a #${id} point`;
-  }
+    // studyId로 기존 레코드를 조회
+    const existingFocus = await this.prisma.focus.findUnique({
+      where: { studyId },
+    });
 
-  update(id: number, updatePointDto: UpdatePointDto) {
-    return `This action updates a #${id} point`;
-  }
+    // 기존 레코드가 있으면 포인트를 더해줌
+    if (existingFocus) {
+      const point = await this.prisma.focus.update({
+        where: { studyId },
+        data: { points: existingFocus.points + points },
+      });
 
-  remove(id: number) {
-    return `This action removes a #${id} point`;
+      return point;
+    }
   }
 }

--- a/src/points/points.service.ts
+++ b/src/points/points.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { CreatePointDto } from './dto/create-point.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
@@ -10,19 +10,31 @@ export class PointsService {
   async updatePoint(createPointDto: CreatePointDto) {
     const { studyId, points } = createPointDto;
 
-    // studyId로 기존 레코드를 조회
-    const existingFocus = await this.prisma.focus.findUnique({
-      where: { studyId },
-    });
-
-    // 기존 레코드가 있으면 포인트를 더해줌
-    if (existingFocus) {
-      const point = await this.prisma.focus.update({
+    try {
+      // studyId로 기존 레코드를 조회
+      const existingFocus = await this.prisma.focus.findUnique({
         where: { studyId },
-        data: { points: existingFocus.points + points },
       });
 
-      return point;
+      // 기존 레코드가 있으면 포인트를 더해줌
+      if (existingFocus) {
+        const point = await this.prisma.focus.update({
+          where: { studyId },
+          data: { points: existingFocus.points + points },
+        });
+
+        return point;
+      } else {
+        // 기존 레코드가 없으면 새로 생성
+        const point = await this.prisma.focus.create({
+          data: { studyId, points },
+        });
+
+        return point;
+      }
+    } catch (error) {
+      console.error(error);
+      throw new InternalServerErrorException(`포인트 업데이트에 실패했습니다.`);
     }
   }
 }

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -68,7 +68,8 @@ export class StudiesService {
       orderBy = 'createdAt',
       order = 'desc',
     } = queryParamsDto;
-    return this.prisma.study.findMany({
+
+    const studies = await this.prisma.study.findMany({
       select: {
         id: true,
         name: true,
@@ -76,11 +77,22 @@ export class StudiesService {
         intro: true,
         background: true,
         createdAt: true, // 0일째 진행중 표기를 위해 createdAt 필드 추가
+        focus: {
+          select: {
+            points: true,
+          },
+        },
       },
       skip: Number((page - 1) * take) || 0,
       take: Number(take) || 6,
       orderBy: { [orderBy || 'createdAt']: order || 'desc' },
     });
+
+    return studies.map((study) => ({
+      ...study,
+      points: study.focus?.points,
+      focus: undefined,
+    }));
   }
 
   async searchStudies(@Query() searchKeywordDto: SearchKeywordDto) {

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -88,10 +88,9 @@ export class StudiesService {
       orderBy: { [orderBy || 'createdAt']: order || 'desc' },
     });
 
-    return studies.map((study) => ({
+    return studies.map(({ focus, ...study }) => ({
       ...study,
-      points: study.focus?.points,
-      focus: undefined,
+      points: focus?.points ?? 0,
     }));
   }
 
@@ -153,10 +152,11 @@ export class StudiesService {
       },
     });
 
+    const { focus, ...studyWithoutFocus } = study;
+
     return {
-      ...study,
-      points: study.focus?.points,
-      focus: undefined,
+      ...studyWithoutFocus,
+      points: focus?.points ?? 0,
     };
   }
 

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -138,12 +138,26 @@ export class StudiesService {
 
   async getStudyById(id: string) {
     // return `This action returns a #${id} study`;
-    return this.prisma.study.findUnique({
+
+    const study = await this.prisma.study.findUnique({
       omit: this.SENSITIVE_FIELDS,
       where: {
         id,
       },
+      include: {
+        focus: {
+          select: {
+            points: true,
+          },
+        },
+      },
     });
+
+    return {
+      ...study,
+      points: study.focus?.points,
+      focus: undefined,
+    };
   }
 
   async updateStudy(id: string, updateStudyDto: UpdateStudyDto) {

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -46,7 +46,14 @@ export class StudiesService {
   async createStudy(createStudyDto: CreateStudyDto) {
     // 스터디 생성 시, 스터디 정보를 생성하고, 생성한 스터디의 ID를 반환
     const study = await this.prisma.study.create({
-      data: createStudyDto,
+      data: {
+        ...createStudyDto,
+        focus: {
+          create: {
+            points: 0,
+          },
+        },
+      },
     });
     return CreateStudyResponseDto.of(study.id);
   }


### PR DESCRIPTION
- study - focus 스키마 1:다 관계 -> 1:1 관계로 수정
- focus 필요없는 필드 제거
- study 생성시, focus 테이블 포인트 자동생성 추가
- 스터디 목록 조회 반환값에 points 추가
- 스터디 상세 목록 조회 반환값에 points 추가
![image](https://github.com/user-attachments/assets/e2484cc1-318f-4609-9f6a-ce77bad4eb6c)

Q. 스터디 집중을 여러번 작동시 어떻게 되는가?
A. study와 focus 테이블의 관계가 1:1으로써, 포인트만 증가하는 형태만 된다.

API 추가 `/points/{studyId}`
![image](https://github.com/user-attachments/assets/70d04961-6d9d-4afc-9b9d-20bfd6917524)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- `Focus` 모델과 `Study` 모델 간의 관계를 1:1로 변경하여 각 집중 기록이 하나의 학습 기록에만 연결되도록 했습니다.
	- `CreatePointDto`에 `points` 및 `studyId` 속성을 추가하여 데이터 구조를 개선했습니다.
	- `PointsController`에 새로운 `updatePoint` 메서드를 추가하여 포인트 업데이트 기능을 제공했습니다.
	- `StudiesService`에서 `points` 속성을 최상위 프로퍼티로 노출하도록 데이터 반환 구조를 변경했습니다.

- **Bug Fixes**
	- `Focus` 모델에서 `startTime` 및 `endTime` 필드를 제거하여 불필요한 데이터 손실 경고를 방지했습니다.
	- `studyId` 필드에 대한 고유 제약 조건을 추가하여 데이터 무결성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->